### PR TITLE
chore: add ruff linting, installation guid updates, fix unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,4 @@ client/node_modules/
 *.tsbuildinfo
 
 processing/
+.pancreator/

--- a/.gitignore
+++ b/.gitignore
@@ -93,7 +93,6 @@ venv.bak/
 .vscode/
 
 # Ruff
-ruff.toml
 *.ruff_cache/
 
 # Pytest
@@ -135,7 +134,6 @@ config/*
 *.code-workspace
 
 .cursor/
-.local/
 
 # DB dumps
 .backup/

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Edit `.env` with your data paths and database credentials. See [Environment vari
 Use a dedicated virtual environment — do not install into the system Python.
 
 ```bash
+# Verify interpreter first. Must be 3.9, 3.10, or 3.11.
+python --version
+
 python -m venv .venv
 source .venv/bin/activate   # Windows: .venv\Scripts\activate
 
@@ -63,11 +66,15 @@ pip install --no-build-isolation -r requirements.txt
 pip install -e .
 ```
 
-If you use [pyenv](https://github.com/pyenv/pyenv), install and select a 3.9–3.11 interpreter before creating the venv:
+If `python --version` is outside 3.9–3.11 (for example 3.8), select a supported interpreter first.
+With [pyenv](https://github.com/pyenv/pyenv):
 
 ```bash
 pyenv install 3.11    # skip if you already have a suitable 3.9–3.11 version
 pyenv local 3.11      # optional; .python-version is gitignored
+
+# then re-run venv creation with the selected interpreter
+python -m venv .venv
 ```
 
 #### Python version notes
@@ -150,7 +157,7 @@ python -m src.scripts.index_tracks
 python -m src.scripts.run_api
 
 # 4. Client dev server
-cd client && npm install && npm run dev
+cd client && npm ci && npm run dev
 ```
 
 The Vite dev server proxies `/api/*` requests to the API.

--- a/client/src/components/SetBuilder.test.tsx
+++ b/client/src/components/SetBuilder.test.tsx
@@ -440,7 +440,7 @@ describe('SetBuilder', () => {
           track: { id: 42, title: 'Drag Me', artist_names: [], bpm: 128, key: 'C', camelot_code: '8B', genre: null, label: null, energy: null },
         }],
         explorer_nodes: [{
-          id: 1, set_id: 1, node_id: 'n1', track_id: 99, level: 0,
+          id: 1, set_id: 1, node_id: 'n1', track_id: 99, level: 0, col_index: 0,
           track: { id: 99, title: 'Root Node', artist_names: [], bpm: 130, key: 'D', camelot_code: '10A', genre: null, label: null, energy: null },
         }],
         explorer_edges: [],
@@ -496,7 +496,7 @@ describe('SetBuilder', () => {
     it('shows per-level +Add Track button on explorer', async () => {
       const hydrated = makeHydratedSet({
         explorer_nodes: [{
-          id: 1, set_id: 1, node_id: 'n1', track_id: 10, level: 0,
+          id: 1, set_id: 1, node_id: 'n1', track_id: 10, level: 0, col_index: 0,
           track: { id: 10, title: 'Root', artist_names: [], bpm: 128, key: 'C', camelot_code: '8B', genre: null, label: null, energy: null },
         }],
         explorer_edges: [],
@@ -519,9 +519,9 @@ describe('SetBuilder', () => {
     it('shows per-child resolution controls in delete modal', async () => {
       const hydrated = makeHydratedSet({
         explorer_nodes: [
-          { id: 1, set_id: 1, node_id: 'parent', track_id: 1, level: 0, track: { id: 1, title: 'Parent', artist_names: [], bpm: 128, key: 'C', camelot_code: '8B', genre: null, label: null, energy: null } },
-          { id: 2, set_id: 1, node_id: 'mid', track_id: 2, level: 1, track: { id: 2, title: 'Middle', artist_names: [], bpm: 130, key: 'D', camelot_code: '10A', genre: null, label: null, energy: null } },
-          { id: 3, set_id: 1, node_id: 'child', track_id: 3, level: 2, track: { id: 3, title: 'Child', artist_names: [], bpm: 125, key: 'A', camelot_code: '11B', genre: null, label: null, energy: null } },
+          { id: 1, set_id: 1, node_id: 'parent', track_id: 1, level: 0, col_index: 0, track: { id: 1, title: 'Parent', artist_names: [], bpm: 128, key: 'C', camelot_code: '8B', genre: null, label: null, energy: null } },
+          { id: 2, set_id: 1, node_id: 'mid', track_id: 2, level: 1, col_index: 0, track: { id: 2, title: 'Middle', artist_names: [], bpm: 130, key: 'D', camelot_code: '10A', genre: null, label: null, energy: null } },
+          { id: 3, set_id: 1, node_id: 'child', track_id: 3, level: 2, col_index: 0, track: { id: 3, title: 'Child', artist_names: [], bpm: 125, key: 'A', camelot_code: '11B', genre: null, label: null, energy: null } },
         ],
         explorer_edges: [
           { id: 1, set_id: 1, parent_node_id: 'parent', child_node_id: 'mid' },

--- a/client/src/components/SetExplorerCanvas.test.tsx
+++ b/client/src/components/SetExplorerCanvas.test.tsx
@@ -901,7 +901,6 @@ describe('SetExplorerCanvas', () => {
     const BUCKET_GAP = 8;
 
     function parentX(col: number) { return col * SLOT_W + (SLOT_W - NODE_W) / 2; }
-    function parentCX(col: number) { return parentX(col) + NODE_W / 2; }
     function parentBottom(level: number) { return TOP_PAD + level * (NODE_H + V_GAP) + NODE_H; }
     function nodeSlotX25(nodeX: number, laneIndex: number) {
       const bucket = Math.floor(laneIndex / EDGE_SLOTS);

--- a/client/src/components/SetExplorerCanvas.tsx
+++ b/client/src/components/SetExplorerCanvas.tsx
@@ -814,16 +814,6 @@ export function SetExplorerCanvas({
     return map;
   }, [allFlat]);
 
-  const parentChildMap = useMemo(() => {
-    const map = new Map<string, string[]>();
-    for (const e of edges) {
-      const list = map.get(e.parent_node_id) ?? [];
-      list.push(e.child_node_id);
-      map.set(e.parent_node_id, list);
-    }
-    return map;
-  }, [edges]);
-
   return (
     <div className="set-explorer">
       <div className="set-explorer-controls">

--- a/client/src/hooks/useSetBuilder.test.ts
+++ b/client/src/hooks/useSetBuilder.test.ts
@@ -54,11 +54,22 @@ function makeTrack(id: number, title = `Track ${id}`): Track {
 function makeExplorerNode(
   overrides: Partial<ExplorerNode> & { node_id: string; track_id: number; level: number },
 ): ExplorerNode {
+  const {
+    node_id,
+    track_id,
+    level,
+    col_index = 0,
+    ...rest
+  } = overrides;
   return {
     id: 1,
     set_id: 1,
-    track: makeTrack(overrides.track_id),
-    ...overrides,
+    node_id,
+    track_id,
+    level,
+    col_index,
+    track: makeTrack(track_id),
+    ...rest,
   };
 }
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,11 @@
+target-version = "py39"
+
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".venv",
+    ".vscode",
+    "build",
+    "dist"
+]
+
+lint.ignore = ["F405"]

--- a/src/config.py
+++ b/src/config.py
@@ -22,7 +22,7 @@ def _invalidate_stale_numba_cache() -> None:
     import site
 
     try:
-        import numpy as np  # noqa: delayed — must not trigger at module scope
+        import numpy as np  # delayed — must not trigger at module scope
     except ImportError:
         return
 
@@ -51,7 +51,7 @@ def _invalidate_stale_numba_cache() -> None:
 
 _invalidate_stale_numba_cache()
 
-from dotenv import load_dotenv
+from dotenv import load_dotenv  # noqa: E402
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 load_dotenv(_REPO_ROOT / ".env")

--- a/src/scripts/feature_extraction/retry_failed_traits.py
+++ b/src/scripts/feature_extraction/retry_failed_traits.py
@@ -2,7 +2,7 @@
 
 Queries tracks present in ``track`` but missing from ``track_trait`` (filtered
 to audio extensions), then recomputes traits single-threaded with full
-traceback logging to the RCA run directory.  Safe to re-run — already-computed
+traceback logging to ``logs/trait_failure_retry.txt``.  Safe to re-run — already-computed
 tracks are skipped by the NOT-IN query.
 
 Usage:
@@ -25,10 +25,7 @@ from src.utils.file_operations import AUDIO_TYPES  # noqa: E402
 from src.feature_extraction.trait_extractor import TraitExtractor  # noqa: E402
 from src.scripts.feature_extraction.compute_track_traits import _resolve_audio_path  # noqa: E402
 
-LOG_FILE = (
-    Path(__file__).resolve().parents[3]
-    / ".local/cursor-meta/runs/2026-03-31_trait_failure_rca/failure_log.txt"
-)
+LOG_FILE = Path(__file__).resolve().parents[3] / "logs" / "trait_failure_retry.txt"
 
 _PROGRESS_INTERVAL = 10
 

--- a/src/tests/test_ingestion_pipeline.py
+++ b/src/tests/test_ingestion_pipeline.py
@@ -2,13 +2,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from src.ingestion_pipeline.config import TAG_COLUMNS
 from src.ingestion_pipeline.tag_record_factory import (
     FinalRecordFactory,
     InitialRecordFactory,
     PostMIKRecordFactory,
     PostRBRecordFactory,
-    TagRecordFactory,
 )
 
 

--- a/src/tests/test_retry_failed_traits.py
+++ b/src/tests/test_retry_failed_traits.py
@@ -1,0 +1,10 @@
+"""Unit tests for retry_failed_traits configuration."""
+
+from pathlib import Path
+
+from src.scripts.feature_extraction.retry_failed_traits import LOG_FILE
+
+
+def test_log_file_is_under_repo_logs():
+    repo_root = Path(__file__).resolve().parents[2]
+    assert LOG_FILE == repo_root / "logs" / "trait_failure_retry.txt"

--- a/src/tests/test_set_workspace_explorer.py
+++ b/src/tests/test_set_workspace_explorer.py
@@ -1,6 +1,5 @@
 """Tests for explorer graph rules and validation."""
 
-import pytest
 
 from src.set_workspace.explorer_rules import (
     detect_cycle,

--- a/src/tests/test_weight_service.py
+++ b/src/tests/test_weight_service.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from src.harmonic_mixing.config import MATCH_WEIGHTS, MatchFactors
+from src.harmonic_mixing.config import MatchFactors
 
 
 def _make_service(**overrides):
@@ -253,7 +253,7 @@ class TestEnsureTableBehavior:
              ):
             from src.harmonic_mixing.weight_service import WeightService
 
-            svc = WeightService()
+            WeightService()
             mock_et.assert_called_once()
 
     def test_load_succeeds_when_ensure_table_raises(self):


### PR DESCRIPTION
## Summary
Adds checked-in Ruff configuration, normalizes trait-retry failure logging under the repo logs tree, and tightens setup documentation so developers verify a supported Python version and use reproducible client installs. Test and lint cleanup fixes explorer fixture data, removes unused code paths, and clears import noise uncovered by the new linter.

## Changelist

- Add Ruff configuration for Python 3.9 with standard excludes and targeted lint ignores, and apply matching fixes in application code
- Clarify backend and client onboarding: verify Python 3.9–3.11 before creating a venv, document pyenv re-run steps, and prefer `npm ci` for the Vite dev workflow
- Move trait failure retry traceback logging into the repo logs directory and add coverage for the configured log path
- Stabilize Set Builder and explorer tests by supplying required node layout fields and fixing test helper override merging
- Remove unused explorer canvas memoization, stale test helpers, and unused Python test imports